### PR TITLE
Prevent large files

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -13,3 +13,4 @@ connect_timeout = 20000
 max_retries = 3
 pause_gateway_seconds = 120
 delete_after_days = 5
+max_content_length = 104857600 # 100MB

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ pub struct Settings {
     pub max_retries: u32,
     pub pause_gateway_seconds: i64,
     pub delete_after_days: i64,
+    pub max_content_length: u64,
 }
 
 impl Settings {


### PR DESCRIPTION
Add a new config flag to set a size limit to fetched files.